### PR TITLE
docs(.github): fixed link to dockerize

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Identus provides components to develop decentralized identity solutions that adh
 ## Quick Start Guide and Documentation
 
 To quickly get up and running and explore the project's capabilities:
-- Follow the instructions in 💻 [dockerize-identus.md](identus-docker/dockerize-identus.md) to have a local environment up and running.
+- Follow the instructions in 💻 [dockerize-identus.md](https://github.com/hyperledger-identus/.github/blob/main/identus-docker/dockerize-identus.md) to have a local environment up and running.
 - Try the ⚡[Quick Start Guide](https://hyperledger-identus.github.io/docs/home/quick-start/) to explore the capabilities of Identus step by step.
 - Find more details about any topic you need by reading the project's 📄 [Documentation](https://hyperledger-identus.github.io/docs/).
 


### PR DESCRIPTION
Relative link to `dockerize-identus.md` didn't work when being included in the Github Profile page. 

Changed it to be a full URI so it will work anywhere in the project.